### PR TITLE
Add getters for emails

### DIFF
--- a/YiiMailer.php
+++ b/YiiMailer.php
@@ -563,4 +563,18 @@ class YiiMailer extends PHPMailer {
 		}
 	}
 
+	public function getTo()
+	{
+		return $this->to;
+	}
+
+	public function getCC()
+	{
+		return $this->cc;
+	}
+
+	public function getBcc()
+	{
+		return $this->bcc;
+	}
 }


### PR DESCRIPTION
It is necessary to sometimes pull out the emails from the mailer class before sending.  This pull adds getters on the email properties.
