### PR TITLE
Update composer.json to allow for later versions of phpmailer than 5.2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,6 @@
 	"description": "Yii extension for sending emails with layouts using PHPMailer",
 	"require": {
         	"php": ">=5.0.0",
-		"phpmailer/phpmailer": "v5.2.6"
+            "phpmailer/phpmailer": "5.2.*"
 	}
 }


### PR DESCRIPTION
I needed to install PHPMailer > 5.2.14, but the PHPMailer version was hardcoded in composer.json.  This patch allows for minor version updates as necessary.
