### PR TITLE
 Always append uniqid to filename

### DIFF
--- a/src/YiiMailer.php
+++ b/src/YiiMailer.php
@@ -577,7 +577,7 @@ class YiiMailer extends PHPMailer
      */
     public function save()
     {
-        $filename = date('YmdHis') . '_' . (empty($this->view) ? uniqid() : $this->view) . '.eml';
+        $filename = date('YmdHis') . (!empty($this->view) ? '_' . $this->view : '') . '_' . uniqid() . '.eml';
         $dir = Yii::getPathOfAlias($this->savePath);
 
         // Create a directory


### PR DESCRIPTION
Avoids name collisions when called more than once in rapid succession.